### PR TITLE
now also setting fusion@inframe ...

### DIFF
--- a/R/importStarfusion.R
+++ b/R/importStarfusion.R
@@ -52,7 +52,8 @@ importStarfusion <- function (filename, genomeVersion, limit) {
         "LeftBreakEntropy" = col_number(),
         "RightBreakDinuc" = col_character(),
         "RightBreakEntropy" = col_number(),
-        "FFPM" = col_number()
+        "FFPM" = col_number(),
+        "PROT_FUSION_TYPE" = col_character()
       )
       if (missing(limit)) {
         # Read all lines
@@ -103,6 +104,17 @@ importStarfusion <- function (filename, genomeVersion, limit) {
     fusionToolSpecificData[["RightBreakEntropy"]] = report[[i, "RightBreakEntropy"]]
     fusionToolSpecificData[["FFPM"]] = report[[i, "FFPM"]]
 
+    if(!is.null(report$PROT_FUSION_TYPE)) {
+        ## only available when loading from coding_effect file (i.e.
+        ## star-fusion.fusion_predictions.abridged.annotated.coding_effect.tsv)
+        ft <- report[[i, "PROT_FUSION_TYPE"]]
+        fusionToolSpecificData[["inframe"]] <- ft
+        if (ft == 'INFRAME')
+          inframe <- TRUE
+        if (ft == 'FRAMESHIFT')
+          inframe <- FALSE
+    }
+    
     # id for this fusion
     id <- as.character(i)
 


### PR DESCRIPTION
... but only if column PROT_FUSION_TYPE is available (i.e. when reading
star-fusion.fusion_predictions.abridged.annotated.coding_effect.tsv )
If the (default) "star-fusion.fusion_predictions.abridged.tsv" file
is used, inframe remains NA (and a warning is issued)
now also setting fusion@inframe ...

(cherry picked from commit a8fc9cbb239d1c498cdbf3bf97885cafb02e8977)