### PR TITLE
switch to checkmate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Imports:
     plyr,
     dplyr,
     BiocStyle,
-    ArgumentCheck,
+    checkmate,
     gtools,
     magick
 Depends:

--- a/R/plot_circle.R
+++ b/R/plot_circle.R
@@ -304,53 +304,37 @@ plot_circle <- function(fusion_list) {
 .validate_plot_circle_params <- function(
   fusion_list
 ) {
-  # Establish a new 'ArgCheck' object
-  argument_checker <- ArgumentCheck::newArgCheck()
+  # Establish a new 'checkmate' object
+  coll <- checkmate::makeAssertCollection()
 
   # Check input type and length
-  if (
-    !is.list(fusion_list) ||
-      length(fusion_list) == 0
-  ) {
-    ArgumentCheck::addError(
-      msg = "'fusion_list' must be a list of fusion objects",
-      argcheck = argument_checker
-    )
-  }
-  # Check that all the items in the input list are fusion objects
-  for (i in seq_along(fusion_list)) {
-    if (class(fusion_list[[i]]) != "Fusion") {
-      ArgumentCheck::addError(
-        msg = "'fusionList' must be a list of fusion objects",
-        argcheck = argument_checker
-      )
-      break
-    }
-  }
+  # Cehck that all the items in the input list are fusion objects
+  checkmate::assert_list(x = fusion_list,
+                         min.len = 1,
+                         types = "Fusion")
 
   # Validate that the first fusion object has a valid genome
   genome_of_first_fusion <- fusion_list[[1]]@genome_version
   if (!genome_of_first_fusion %in% list("hg19", "hg38", "mm10")) {
-    ArgumentCheck::addError(
-      msg = paste0(
+    coll$push(
+      paste0(
         "Invalid input. genomeVersion must be either \"hg19\", \"hg38\" or ",
         "\"mm10\"."
-      ),
-      argcheck = argument_checker
+      )
     )
   }
+
   # Validate that all the fusions have the same genome
-  for (i in seq_along(fusion_list)) {
-    if (!fusion_list[[i]]@genome_version == genome_of_first_fusion) {
-      ArgumentCheck::addError(
-        msg = paste0(
-          "All Fusion objects in the fusion_list must have the same genome."
-        ),
-        argcheck = argument_checker
+  genome_version <- sapply(seq_along(fusion_list),
+                           function(fl) fusion_list[[fl]]@genome_version)
+  if (any(genome_version != genome_of_first_fusion)){
+    coll$push(
+      paste0(
+        "All Fusion objects in the fusion_list must have the same genome."
       )
-    }
+    )
   }
 
   # Return errors and warnings (if any)
-  ArgumentCheck::finishArgCheck(argument_checker)
+  checkmate::reportAssertions(coll)
 }

--- a/R/plot_fusion.R
+++ b/R/plot_fusion.R
@@ -1746,30 +1746,31 @@ import_function_non_ucsc <- function (file, selection) {
   bedgraphfile
 ) {
   # Establish a new 'ArgCheck' object
-  argument_checker <- ArgumentCheck::newArgCheck()
+  argument_checker <- checkmate::makeAssertCollection()
+  # argument_checker <- ArgumentCheck::newArgCheck()
 
   # Check parameters
-  argument_checker <- .is_fusion_valid(argument_checker, fusion)
-  argument_checker <- .is_edb_valid(argument_checker, edb, fusion)
-  argument_checker <- .is_bamfile_bedgraphfile_valid(
+  .is_fusion_valid(argument_checker, fusion)
+  .is_edb_valid(argument_checker, edb, fusion)
+  .is_bamfile_bedgraphfile_valid(
     argument_checker,
     bamfile,
     bedgraphfile
   )
-  argument_checker <- .is_which_transcripts_valid(
+  .is_which_transcripts_valid(
     argument_checker,
     which_transcripts,
     fusion)
-  argument_checker <- .is_ylim_valid(argument_checker, ylim)
-  argument_checker <- .is_parameter_boolean(
+  .is_ylim_valid(argument_checker, ylim)
+  .is_parameter_boolean(
     argument_checker,
     non_ucsc,
     "non_ucsc")
-  argument_checker <- .is_parameter_boolean(
+  .is_parameter_boolean(
     argument_checker,
     reduce_transcripts,
     "reduce_transcripts")
 
   # Return errors and warnings (if any)
-  ArgumentCheck::finishArgCheck(argument_checker)
+  checkmate::reportAssertions(argument_checker)
 }

--- a/R/plot_fusion_reads.R
+++ b/R/plot_fusion_reads.R
@@ -247,34 +247,33 @@ plot_fusion_reads <- function(
   nucleotide_amount
 ) {
   # Establish a new 'ArgCheck' object
-  argument_checker <- ArgumentCheck::newArgCheck()
+  argument_checker <- checkmate::makeAssertCollection()
 
-  argument_checker <- .is_fusion_valid(argument_checker, fusion)
+  .is_fusion_valid(argument_checker, fusion)
 
   # Check if the Gviz::AlignmentsTrack object in
   # fusion@fusion_reads_alignment actually holds data, and is not just the empty
   # object it is after loading the initial fusion data. In other words, make
   # sure add_fusion_reads_alignment() has been run.
   if (class(fusion@fusion_reads_alignment) != "ReferenceAlignmentsTrack") {
-    ArgumentCheck::addError(
-      msg = paste("fusion@fusion_reads_alignment should hold a",
+    argument_checker$push(
+      paste("fusion@fusion_reads_alignment should hold a",
                   "Gviz::ReferenceAlignmentsTrack object.",
-                  "See add_fusion_reads_alignment()."),
-      argcheck = argument_checker
+                  "See add_fusion_reads_alignment().")
     )
   }
 
-  argument_checker <- .is_parameter_boolean(
+  .is_parameter_boolean(
     argument_checker,
     show_all_nucleotides,
     "show_all_nucleotides")
 
-  argument_checker <- .is_nucleotide_amount_valid(
+  .is_nucleotide_amount_valid(
     argument_checker,
     nucleotide_amount,
     fusion
   )
 
   # Return errors and warnings (if any)
-  ArgumentCheck::finishArgCheck(argument_checker)
+  checkmate::reportAssertions(argument_checker)
 }

--- a/R/plot_fusion_transcript.R
+++ b/R/plot_fusion_transcript.R
@@ -354,31 +354,30 @@ plot_fusion_transcript <- function(
   bedgraphfile
 ) {
   # Establish a new 'ArgCheck' object
-  argument_checker <- ArgumentCheck::newArgCheck()
+  argument_checker <- checkmate::makeAssertCollection()
 
   # Check parameters
-  argument_checker <- .is_fusion_valid(argument_checker, fusion)
-  argument_checker <- .is_edb_valid(argument_checker, edb, fusion)
+  .is_fusion_valid(argument_checker, fusion)
+  .is_edb_valid(argument_checker, edb, fusion)
   # Either bamfile or bedgraphfile can be given, not both
   bamfile_given <- !is.null(bamfile)
   bedgraphfile_given <- !is.null(bedgraphfile)
   if (bamfile_given && bedgraphfile_given) {
-    ArgumentCheck::addError(
-      msg = "Either 'bamfile' or 'bedgraphfile' must be given, not both.",
-      argcheck = argument_checker
+    argument_checker$push(
+      "Either 'bamfile' or 'bedgraphfile' must be given, not both."
     )
   }
   if (bamfile_given) {
-    argument_checker <- .is_bamfile_valid(argument_checker, bamfile)
+    .is_bamfile_valid(argument_checker, bamfile)
   }
   if (bedgraphfile_given) {
-    argument_checker <- .is_bedgraphfile_valid(argument_checker, bedgraphfile)
+    .is_bedgraphfile_valid(argument_checker, bedgraphfile)
   }
-  argument_checker <- .is_which_transcripts_valid(
+  .is_which_transcripts_valid(
     argument_checker,
     which_transcripts,
     fusion)
 
   # Return errors and warnings (if any)
-  ArgumentCheck::finishArgCheck(argument_checker)
+  checkmate::reportAssertions(argument_checker)
 }

--- a/R/plot_fusion_transcript_with_protein_domain.R
+++ b/R/plot_fusion_transcript_with_protein_domain.R
@@ -843,27 +843,27 @@ plot_fusion_transcript_with_protein_domain <- function(
   gene_downstream_transcript,
   plot_downstream_protein_domains_if_fusion_is_out_of_frame
 ) {
-  # Establish a new 'ArgCheck' object
-  argument_checker <- ArgumentCheck::newArgCheck()
+  # Establish a new 'AssertCollection' object
+  argument_checker <- checkmate::makeAssertCollection()
 
   # Check parameters
-  argument_checker <- .is_fusion_valid(argument_checker, fusion)
-  argument_checker <- .is_edb_valid(argument_checker, edb, fusion)
-  argument_checker <- .is_bamfile_valid_allow_null(argument_checker, bamfile)
-  argument_checker <- .is_bedfile_valid(argument_checker, bedfile)
-  argument_checker <- .is_character_parameter_valid(
+  .is_fusion_valid(argument_checker, fusion)
+  .is_edb_valid(argument_checker, edb, fusion)
+  .is_bamfile_valid_allow_null(argument_checker, bamfile)
+  .is_bedfile_valid(argument_checker, bedfile)
+  .is_character_parameter_valid(
     argument_checker,
     gene_upstream_transcript,
     "gene_upstream_transcript")
-  argument_checker <- .is_character_parameter_valid(
+  .is_character_parameter_valid(
     argument_checker,
     gene_downstream_transcript,
     "gene_downstream_transcript")
-  argument_checker <- .is_parameter_boolean(
+  .is_parameter_boolean(
     argument_checker,
     plot_downstream_protein_domains_if_fusion_is_out_of_frame,
     "plot_downstream_protein_domains_if_fusion_is_out_of_frame")
 
   # Return errors and warnings (if any)
-  ArgumentCheck::finishArgCheck(argument_checker)
+  checkmate::reportAssertions(argument_checker)
 }

--- a/R/plot_fusion_transcripts_graph.R
+++ b/R/plot_fusion_transcripts_graph.R
@@ -252,13 +252,13 @@ plot_fusion_transcripts_graph <- function(
   which_transcripts,
   rankdir
 ) {
-  # Establish a new 'ArgCheck' object
-  argument_checker <- ArgumentCheck::newArgCheck()
+  # Establish a new 'AssertCollection' object
+  argument_checker <- checkmate::makeAssertCollection()
 
   # Check parameters
-  argument_checker <- .is_fusion_valid(argument_checker, fusion)
-  argument_checker <- .is_edb_valid(argument_checker, edb, fusion)
-  argument_checker <- .is_which_transcripts_valid(
+  .is_fusion_valid(argument_checker, fusion)
+  .is_edb_valid(argument_checker, edb, fusion)
+  .is_which_transcripts_valid(
     argument_checker,
     which_transcripts,
     fusion)
@@ -266,21 +266,19 @@ plot_fusion_transcripts_graph <- function(
   # The "withinExon" option for which_transcripts will not work for the fusion
   # transcripts graph plot. Check if that was the wanted option
   if (which_transcripts[[1]] == "withinExon") {
-    ArgumentCheck::addError(
-      msg = paste0("The \"withinExon\" option for which_transcripts will not ",
-                   "work for the fusion transcripts graph plot, as only ",
-                   "complete exons can be shown."),
-      argcheck = argument_checker
+    argument_checker$push(
+      paste0("The \"withinExon\" option for which_transcripts will not ",
+             "work for the fusion transcripts graph plot, as only ",
+             "complete exons can be shown.")
     )
   }
 
   if (class(rankdir) != "character" || !rankdir %in% c("LR", "TB")) {
-    ArgumentCheck::addError(
-      msg = "'rankdir' must be one of \"LR\" or \"TB\"",
-      argcheck = argument_checker
+    argument_checker$push(
+      "'rankdir' must be one of \"LR\" or \"TB\""
     )
   }
 
   # Return errors and warnings (if any)
-  ArgumentCheck::finishArgCheck(argument_checker)
+  checkmate::reportAssertions(argument_checker)
 }

--- a/R/plot_transcripts.R
+++ b/R/plot_transcripts.R
@@ -670,41 +670,40 @@ plot_transcripts <- function(
   reduce_transcripts,
   bedgraphfile
 ) {
-  # Establish a new 'ArgCheck' object
-  argument_checker <- ArgumentCheck::newArgCheck()
+  # Establish a new 'AssertCollection' object
+  argument_checker <- checkmate::makeAssertCollection()
 
   # Check parameters
-  argument_checker <- .is_fusion_valid(argument_checker, fusion)
-  argument_checker <- .is_edb_valid(argument_checker, edb, fusion)
+  .is_fusion_valid(argument_checker, fusion)
+  .is_edb_valid(argument_checker, edb, fusion)
   # Either bamfile or bedgraphfile can be given, not both
   bamfile_given <- !is.null(bamfile)
   bedgraphfile_given <- !is.null(bedgraphfile)
   if (bamfile_given && bedgraphfile_given) {
-    ArgumentCheck::addError(
-      msg = "Either 'bamfile' or 'bedgraphfile' must be given, not both.",
-      argcheck = argument_checker
+    argument_checker$push(
+      "Either 'bamfile' or 'bedgraphfile' must be given, not both."
     )
   }
   if (bamfile_given) {
-    argument_checker <- .is_bamfile_valid(argument_checker, bamfile)
+    .is_bamfile_valid(argument_checker, bamfile)
   }
   if (bedgraphfile_given) {
-    argument_checker <- .is_bedgraphfile_valid(argument_checker, bedgraphfile)
+    .is_bedgraphfile_valid(argument_checker, bedgraphfile)
   }
-  argument_checker <- .is_which_transcripts_valid(
+  .is_which_transcripts_valid(
     argument_checker,
     which_transcripts,
     fusion)
-  argument_checker <- .is_ylim_valid(argument_checker, ylim)
-  argument_checker <- .is_parameter_boolean(
+  .is_ylim_valid(argument_checker, ylim)
+  .is_parameter_boolean(
     argument_checker,
     non_ucsc,
     "non_ucsc")
-  argument_checker <- .is_parameter_boolean(
+  .is_parameter_boolean(
     argument_checker,
     reduce_transcripts,
     "reduce_transcripts")
 
   # Return errors and warnings (if any)
-  ArgumentCheck::finishArgCheck(argument_checker)
+  checkmate::reportAssertions(argument_checker)
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1097,111 +1097,76 @@ down_shift <- function(transcript) {
 
 .is_fusion_valid <- function(argument_checker, fusion) {
   # Check if we got a fusion object
-  if (class(fusion) != "Fusion") {
-    ArgumentCheck::addError(
-      msg = "'fusion' argument must be an object of type Fusion",
-      argcheck = argument_checker
-    )
-  }
-  argument_checker
+  checkmate::assert_class(x = fusion,
+                          classes = "Fusion",
+                          add = argument_checker)
 }
 
 .is_edb_valid <- function(argument_checker, edb, fusion) {
-  if (!is.null(edb)) {
-    # If we got an edb object, check its validity
-    if (class(edb) != "EnsDb") {
-      ArgumentCheck::addError(
-        msg = "'edb' argument must be an object of type EnsDb",
-        argcheck = argument_checker
-      )
-    }
+  if (!is.null(edb)){
+    checkmate::assert_class(x = edb,
+                            classes = "EnsDb",
+                            add = argument_checker)
   } else {
-    # If edb is not given then the fusion should have transcripts for both genes
     if (isEmpty(fusion@gene_upstream@transcripts)) {
-      ArgumentCheck::addError(
-        msg = paste0("There are no transcipts for gene A. Please provide an ",
+      argument_checker$push(
+        paste0("There are no transcipts for gene A. Please provide an ",
                      "EnsDb object to the edb parameter, or see",
-                     "get_transcripts_ensembl_db()."),
-        argcheck = argument_checker
+               "get_transcripts_ensembl_db().")
       )
     } else if (isEmpty(fusion@gene_downstream@transcripts)) {
-      ArgumentCheck::addError(
-        msg = paste0("There are no transcipts for gene B. Please provide an ",
-                     "EnsDb object to the edb parameter, or see",
-                     "get_transcripts_ensembl_db()."),
-        argcheck = argument_checker
+      argument_checker$push(
+        paste0("There are no transcipts for gene B. Please provide an ",
+               "EnsDb object to the edb parameter, or see",
+               "get_transcripts_ensembl_db().")
       )
     }
   }
-  argument_checker
 }
 
 .is_bamfile_valid_allow_null <- function(argument_checker, bamfile) {
-  # Check that the argument is given
-  if (!is.null(bamfile)) {
-    # Check that the file exists
-    if (!file.exists(bamfile)) {
-      ArgumentCheck::addError(
-        msg = "The given 'bamfile' does not exist.",
-        argcheck = argument_checker
-      )
-    }
+  if (!is.null(bamfile)){
+    checkmate::assert_file_exists(x = bamfile,
+                                  add = argument_checker)
   }
-  argument_checker
 }
 
 .is_bamfile_valid <- function(argument_checker, bamfile) {
   # Check that the argument is given
   if (is.null(bamfile)) {
-    ArgumentCheck::addError(
-      msg = "'bamfile' must be the path to a .BAM file.",
-      argcheck = argument_checker
+    argument_checker$push(
+      "'bamfile' must be the path to a .BAM file."
     )
   }
   # Check that the file exists
-  if (!file.exists(bamfile)) {
-    ArgumentCheck::addError(
-      msg = "The given 'bamfile' does not exist.",
-      argcheck = argument_checker
-    )
+  if (!is.null(bamfile)) {
+    checkmate::assert_file_exists(x = bamfile,
+                                  add = argument_checker)
   }
-  argument_checker
 }
 
 .is_bedfile_valid <- function(argument_checker, bedfile) {
   # Check that the argument is given
   if (is.null(bedfile)) {
-    ArgumentCheck::addError(
-      msg = "'bedfile' must be the path to a .BED file.",
-      argcheck = argument_checker
-    )
+    argument_checker$push("'bedfile' must be the path to a .BED file.")
   }
   # Check that the file exists
-  if (!file.exists(bedfile)) {
-    ArgumentCheck::addError(
-      msg = "The given 'bedfile' does not exist.",
-      argcheck = argument_checker
-    )
+  if (!is.null(bedfile)) {
+    checkmate::assert_file_exists(x = bedfile,
+                                  add = argument_checker)
   }
-  argument_checker
 }
 
 .is_bedgraphfile_valid <- function(argument_checker, bedgraphfile) {
   # Check that the argument is given
   if (is.null(bedgraphfile)) {
-    ArgumentCheck::addError(
-      msg = "'bedgraphfile' must be the path to a .bedGraph file.",
-      argcheck = argument_checker
-    )
+    argument_checker$push("'bedgraphfile' must be the path to a .bedGraph file.")
   }
   # Check that the file exists
-  if (!file.exists(bedgraphfile)) {
-    ArgumentCheck::addError(
-      msg = "The given 'bedgraphfile' does not exist.",
-      argcheck = argument_checker
-    )
+  if (!is.null(bedgraphfile)) {
+    checkmate::assert_file_exists(x = bedgraphfile,
+                                  add = argument_checker)
   }
-  argument_checker
 }
 
 .is_bamfile_bedgraphfile_valid <- function(
@@ -1212,18 +1177,16 @@ down_shift <- function(transcript) {
   bamfile_given <- !is.null(bamfile)
   bedgraphfile_given <- !is.null(bedgraphfile)
   if (bamfile_given && bedgraphfile_given) {
-    ArgumentCheck::addError(
-      msg = "Either 'bamfile' or 'bedgraphfile' must be given, not both.",
-      argcheck = argument_checker
+    argument_checker$push(
+      "Either 'bamfile' or 'bedgraphfile' must be given, not both."
     )
   } else if (!bamfile_given && !bedgraphfile_given) {
     # It is OK to not give any of them
   } else if (bamfile_given) {
-    argument_checker <- .is_bamfile_valid(argument_checker, bamfile)
+    .is_bamfile_valid(argument_checker, bamfile)
   } else {
-    argument_checker <- .is_bedgraphfile_valid(argument_checker, bedgraphfile)
+    .is_bedgraphfile_valid(argument_checker, bedgraphfile)
   }
-  argument_checker
 }
 
 .is_which_transcripts_valid <- function(
@@ -1232,11 +1195,10 @@ down_shift <- function(transcript) {
   fusion
 ) {
   if (class(which_transcripts) != "character") {
-    ArgumentCheck::addError(
-      msg = paste0("'which_transcripts' must be a character (or a character ",
-                   "vector) holding the desired transcript category or the ",
-                   "names of specific transcripts."),
-      argcheck = argument_checker
+    argument_checker$push(
+      paste0("'which_transcripts' must be a character (or a character ",
+             "vector) holding the desired transcript category or the ",
+             "names of specific transcripts.")
     )
   }
   # Is which_transcripts valid?
@@ -1254,24 +1216,20 @@ down_shift <- function(transcript) {
       !which_transcripts[[i]] %in% names(fusion@gene_upstream@transcripts) &&
       !which_transcripts[[i]] %in% names(fusion@gene_downstream@transcripts)
     ) {
-      ArgumentCheck::addError(
-        msg = paste0("No transcript with name ", which_transcripts[[i]],
-                     " was found."),
-        argcheck = argument_checker
+      argument_checker$push(
+        paste0("No transcript with name ", which_transcripts[[i]],
+               " was found.")
       )
     }
   }
-  argument_checker
 }
 
 .is_ylim_valid <- function(argument_checker, ylim) {
   if (class(ylim) != "numeric" || length(ylim) != 2) {
-    ArgumentCheck::addError(
-      msg = "'ylim' must be a numeric vector of length 2",
-      argcheck = argument_checker
+    argument_checker$push(
+      "'ylim' must be a numeric vector of length 2"
     )
   }
-  argument_checker
 }
 
 .is_parameter_boolean <- function(
@@ -1279,13 +1237,9 @@ down_shift <- function(transcript) {
   parameter,
   parameter_name
 ) {
-  if (class(parameter) != "logical") {
-    ArgumentCheck::addError(
-      msg = paste0("'", parameter_name, "'", " must be a boolean."),
-      argcheck = argument_checker
-    )
-  }
-  argument_checker
+  checkmate::assert_logical(x = parameter,
+                            .var.name = parameter_name,
+                            add = argument_checker)
 }
 
 .is_character_parameter_valid <- function(
@@ -1293,14 +1247,9 @@ down_shift <- function(transcript) {
   parameter,
   parameter_name
 ) {
-  if (class(parameter) != "character") {
-    ArgumentCheck::addError(
-      msg = paste0("'", parameter_name, "'", " must be a character vector of ",
-                   "length 1 (meaning that it's just a single string)."),
-      argcheck = argument_checker
-    )
-  }
-  argument_checker
+  checkmate::assert_character(x = parameter,
+                              .var.name = parameter_name,
+                              add = argument_checker)
 }
 
 .is_nucleotide_amount_valid <- function(
@@ -1316,26 +1265,22 @@ down_shift <- function(transcript) {
   if (class(nucleotide_amount) != "numeric" ||
       nucleotide_amount <= 0 ||
       nucleotide_amount > fusion_junction_sequence_length) {
-    ArgumentCheck::addError(
-      msg = paste0(
+    argument_checker$push(
+      paste0(
         "'nucleotide_amount' must be a numeric bigger than or equal ",
         "to 0 and less than or equal to the fusion junction ",
         "sequence length."
-      ),
-      argcheck = argument_checker
+      )
     )
   }
 
   if (fusion_junction_sequence_length == 0) {
-    ArgumentCheck::addError(
+    argument_checker$push(
       msg = paste0(
         "length of junction sequence is 0, have they been determined?"
-      ),
-      argcheck = argument_checker
+      )
     )
   }
-
-  argument_checker
 }
 
 # End of functions that validate parameters passed to functions in chimeraviz
@@ -1343,12 +1288,12 @@ down_shift <- function(transcript) {
 
 .get_transcripts_if_not_there <- function(fusion, edb) {
   # Establish a new 'ArgCheck' object
-  argument_checker <- ArgumentCheck::newArgCheck()
+  argument_checker <- checkmate::makeAssertCollection()
   # Check parameters
   argument_checker <- .is_fusion_valid(argument_checker, fusion)
   argument_checker <- .is_edb_valid(argument_checker, edb, fusion)
   # Return errors and warnings (if any)
-  ArgumentCheck::finishArgCheck(argument_checker)
+  checkmate::reportAssertions(argument_checker)
 
   if (
     isEmpty(fusion@gene_upstream@transcripts) ||


### PR DESCRIPTION
Hello, Mr. Lagstad,

I recently received an e-mail from CRAN that the package ArgumentCheck would be removed from CRAN in May if there were not some revisions made to the package. Unfortunately, I lack the time to continue the maintenance on ArgumentCheck, and there are packages available that do the job better anyway.  I plan to allow ArgumentCheck to be removed and am recommending you change `chimeraviz` to use the `checkmate` package.  This pull request makes what, I believe, are the necessary changes to implement `checkmate`

Thanks,